### PR TITLE
theme/snap assign test fixed, back ported from latest stable branch

### DIFF
--- a/tests/assign_test.php
+++ b/tests/assign_test.php
@@ -184,12 +184,12 @@ class theme_snap_assign_test extends mod_assign_base_testcase {
     public function test_participant_count() {
         $courseid = $this->course->id;
         $actual = local::course_participant_count($courseid);
-        $expected = count($this->students);
+        $expected = count($this->students) + count($this->teachers) + count($this->editingteachers);
         $this->assertSame($expected, $actual);
 
         $this->create_extra_users();
         $actual = local::course_participant_count($courseid);
-        $expected = count($this->students);
+        $expected = count($this->students) + count($this->teachers) + count($this->editingteachers);
         $this->assertSame($expected, $actual);
     }
 


### PR DESCRIPTION
The unit test "test_participant_count" was not passing.. I see you have a fix on your latest 3.0 branch. 
I suggest you back port the code changes to your 2.8 branch as well. 