### PR TITLE
Fix assign_meta sql in activity.php

### DIFF
--- a/classes/activity.php
+++ b/classes/activity.php
@@ -169,7 +169,7 @@ class activity {
                       JOIN {assign_plugin_config} ac ON ac.assignment = a.id
                      WHERE a.course = ?
                        AND ac.name='enabled'
-                       AND ac.value=1
+                       AND ac.value='1'
                        AND ac.subtype='assignsubmission'
                        AND plugin!='comments'
                   GROUP BY a.id;";


### PR DESCRIPTION
Currently in the 2.7 branch there is broken sql on line 172 in activity.php doing a text = integer operator. I can see this has already been fixed in the 2.8 branch onward.