### PR TITLE
Missing context is creating warnings

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -209,6 +209,11 @@ function theme_snap_send_file($context, $filearea, $args, $forcedownload, $optio
  * @return bool
  */
 function theme_snap_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = array()) {
+    global $PAGE;
+
+    if (!isset($PAGE->context)) {
+        $PAGE->set_context($context);
+    }
 
     $coverimagecontexts = [CONTEXT_SYSTEM, CONTEXT_COURSE, CONTEXT_COURSECAT];
 


### PR DESCRIPTION
Missing context from pluginfile.php is creating set_context warnings.

E.g., 

PHP message: Debugging: Coding problem: $PAGE->context was not set. You may have forgotten to call require_login() or $PAGE->set_context(). The page may not display correctly as a result in #012* 
 line 572 of /lib/pagelib.php: call to debugging()#012*
 line 1730 of /lib/pagelib.php: call to moodle_page->magic_get_context()#012* 
 line 239 of /theme/snap/config.php: call to moodle_page->initialise_theme_and_output()#012*
 line 2362 of /lib/outputlib.php: call to include()#012* 
 line 710 of /lib/outputlib.php: call to theme_config::find_theme_config()#012* 
 line 229 of /theme/snap/lib.php: call to theme_config::load()#012* line 5316 of /lib/filelib.php: call to theme_snap_pluginfile()#012* 
 line 44 of /pluginfile.php: call to file_pluginfile()" while reading response header from upstream