### PR TITLE
str_contains breaks php7x compatibility

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -163,8 +163,9 @@ class core_renderer extends \theme_boost\output\core_renderer {
         $snapfeedsurlparam = isset($CFG->theme_snap_feeds_url_parameter) ? $CFG->theme_snap_feeds_url_parameter : true;
         if ($location == 'snapfeedsmenu') {
             if ($snapfeedsurlparam) {
-                if (str_contains($langstring, 'viewmessaging') || str_contains($langstring, 'viewmyfeedback')) {
-                    $link = '<a class="snap-feeds-menu-more" href="' .$url. '?snapfeedsclicked=on" title="'.$text.'"><small>' .$text. '</small>' .$icon. '</a>';
+		if ((strpos($langstring, 'viewmessaging') !== false) ||
+    (strpos($langstring, 'viewmyfeedback') !== false)) {
+		    $link = '<a class="snap-feeds-menu-more" href="' .$url. '?snapfeedsclicked=on" title="'.$text.'"><small>' .$text. '</small>' .$icon. '</a>'; 
                 } else {
                     $link = '<a class="snap-feeds-menu-more" href="' .$url. '&snapfeedsclicked=on" title="'.$text.'"><small>' .$text. '</small>' .$icon. '</a>';
                 }


### PR DESCRIPTION
Moodle 4.1 still uses php 7.4.0 https://moodledev.io/general/releases/4.1

str_contains is php 8x only. 

We should use strpos instead while this plugin still accepts Moodle 4.1.