### PR TITLE
Issue #307: Fix: "Invalid module ID" error when deleting Choice activities with availability dates

### DIFF
--- a/classes/activity.php
+++ b/classes/activity.php
@@ -1595,6 +1595,8 @@ class activity {
      */
     public static function user_activity_events(array $courses, $tstart, $tend, $cachesuffix = '', $limit = 500,
                                                 $skipcmchecks = false) {
+        global $DB, $USER;
+
         $retobj = (object) [
             'timestamp' => null,
             'events' => [],
@@ -1618,12 +1620,48 @@ class activity {
         $tmparr = [];
         foreach ($retobj->events as $event) {
 
-            // Validation added to prevent array offset.
-            $courseid = array_key_exists($event->courseid, $courses) ? $courses[$event->courseid] : 0;
+            // Skip events from courses not in the $courses array.
+            if (!array_key_exists($event->courseid, $courses)) {
+                continue;
+            }
 
-            [$course, $cminfo] = get_course_and_cm_from_instance(
-                    $event->instance, $event->modulename,  $courseid, $event->userid);
-            unset($course);
+            $courseid = $courses[$event->courseid];
+
+            try {
+                [$course, $cminfo] = get_course_and_cm_from_instance(
+                        $event->instance, $event->modulename, $courseid, $event->userid);
+                unset($course);
+            } catch (\moodle_exception $e) {
+                // Check if the module is pending delete, fully deleted, or module type doesn't exist.
+                $moduleid = $DB->get_field('modules', 'id', ['name' => $event->modulename], IGNORE_MISSING);
+                $shoulddeletecache = ($moduleid === false);
+
+                if (!$shoulddeletecache) {
+                    $cm = $DB->get_record('course_modules', [
+                        'instance' => $event->instance,
+                        'module' => $moduleid,
+                        'course' => $event->courseid
+                    ], 'id, deletioninprogress', IGNORE_MISSING);
+                    $shoulddeletecache = empty($cm) || !empty($cm->deletioninprogress);
+                }
+
+                if ($shoulddeletecache) {
+                    // Remove the specific cache item.
+                    $cachekey = self::get_id_indexed_array_cache_key($courses);
+                    $groupkey = self::get_user_group_cache_key($USER, $courses);
+                    if (!empty($groupkey)) {
+                        $cachekey .= '_' . $groupkey;
+                    }
+                    if (!empty($cachesuffix)) {
+                        $cachekey .= '_' . $cachesuffix;
+                    }
+
+                    $muc = \cache::make('theme_snap', 'activity_deadlines');
+                    $muc->delete($cachekey);
+                }
+                // Skip events that reference non-existent or invalid module instances.
+                continue;
+            }
 
             // We are only interested in modules with valid instances.
             if (empty($cminfo)) {


### PR DESCRIPTION
Issue #307: Fix: "Invalid module ID" error when deleting Choice activities with availability dates

- Problem: When deleting a Choice activity that has availability dates enabled (specifically "Allow responses until"), users encounter an "Invalid module ID" error on the course page after deletion. This error occurs during the asynchronous deletion window - the period between when a module is flagged for deletion and when the cron task actually completes the deletion.
- Fix: Add exception handling to gracefully skip calendar events that reference modules that are deleted, pending deletion, or have invalid module types.When an exception occurs, check the module status and delete the stale cache entry before continuing with remaining events.

Root Cause

1.  Asynchronous Deletion Process: When a module is deleted in Moodle (with Recycle Bin enabled), it's marked with deletioninprogress = 1 in the mdl_course_modules table and queued for async deletion.
2. Cache Contains Stale Events: The theme_snap/activity_deadlines cache contains calendar events that reference the deleted module. These events remain in the cache even after the module is flagged for deletion.
3. Module Removed from modinfo: When rebuild_course_cache() is called during async deletion flagging, the module is removed from the modinfo cache, making it unavailable to get_course_and_cm_from_instance().
4. Error During Event Processing: When the theme tries to process cached calendar events, it calls get_course_and_cm_from_instance() for each event. For events referencing the deleted module, this function throws an invalidmoduleid exception because the module no longer exists in modinfo.
5. The issue is more noticeable with Choice activity.

Steps to reproduce the issue:
• Create a course
• Add a Choice activity
• Enable “Allow responses until” in the Availability section
• Add options
• Save the activity
• Return to the course page
• Delete the Choice activity just created
• Refresh the course page and "Invalid module ID” error appears